### PR TITLE
16 send logmodel via ipc

### DIFF
--- a/src/JoeScan.LogScanner.Core.Schema/JoeScan.LogScanner.Core.Schema.csproj
+++ b/src/JoeScan.LogScanner.Core.Schema/JoeScan.LogScanner.Core.Schema.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FlatSharpSchema Include="Serialization.fbs" />
+   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FlatSharp.Compiler" Version="7.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FlatSharp.Runtime" Version="7.1.1" />
+  </ItemGroup>
+</Project>
+

--- a/src/JoeScan.LogScanner.Core.Schema/Serialization.fbs
+++ b/src/JoeScan.LogScanner.Core.Schema/Serialization.fbs
@@ -135,7 +135,12 @@ table LogModelT (fs_serializer)
    maxDiameterZ: double;
    minDiameterZ: double;
    buttEndFirst: bool;
-   rawLog: RawLogT;
+}
 
-
+table LogModelResultT (fs_serializer) {
+	LogModel: LogModelT;
+    RawLog: RawLogT;
+    Messages: [string];
+    LogNumber: int32;
+    IsValid: bool;
 }

--- a/src/JoeScan.LogScanner.Core.Schema/Serialization.fbs
+++ b/src/JoeScan.LogScanner.Core.Schema/Serialization.fbs
@@ -1,0 +1,141 @@
+﻿
+attribute "fs_serializer";
+attribute "fs_valueStruct";
+
+
+namespace JoeScan.LogScanner.Core.Schema;
+
+struct Point2DT (fs_valueStruct) // fs_valueStruct tells FlatSharp to generate a C# struct (value type) instead of a class
+{
+    x : double;
+    y : double;
+    b : double;
+}
+struct Point3DT (fs_valueStruct) // fs_valueStruct tells FlatSharp to generate a C# struct (value type) instead of a class
+{
+    x : double;
+    y : double;
+    z : double;
+    b : double;
+}
+
+enum UnitTypeT : byte {
+    Inches = 0,
+    Millimeters = 1
+}
+
+enum ScanFlagsT : int32{
+    None = 0,
+    Overrun = 1,
+    InternalError = 2,
+    SequenceError = 4
+}
+
+enum InputFlagsT : int32{ 
+    None = 0,
+    EncoderB = 1,
+    EncoderA = 2,
+    StartScan = 4
+}
+
+struct  RectT  {
+    x : double ;
+    y: double ;
+    width : double;
+    height : double;
+}
+
+table EllipseT (fs_serializer) {
+    a: double;
+    b: double;
+    area: double;
+    theta: double;
+    x: double;
+    y: double;
+}
+
+table ProfileT (fs_serializer) {
+    units : UnitTypeT;
+    scanningFlags : ScanFlagsT;
+    laserIndex : uint32;
+    laserOnTimeUs : uint16;
+    encoderValue : int64;
+    sequenceNumber : uint32;
+    timeStampNs : uint64;
+    scanHeadId : uint32;
+    camera: uint32;
+    inputs : InputFlagsT;
+    boundingBox : RectT;
+    data : [Point2DT];
+}
+
+table RawLogT (fs_serializer) {
+    profileData: [ProfileT];
+    logNumber: int32;
+    timeScanned: int64;
+    Id: string;
+    rawFileName: string;
+}
+
+table LogSectionT (fs_serializer) {
+    isValid : bool;
+    profiles : [ProfileT];
+    sectionCenter : double;
+    acceptedPoints : [Point2DT];
+    modeledProfile  : [Point2DT];
+    rejectedPoints  : [Point2DT];
+    boundingBox : RectT;
+    ellipseModel : EllipseT;
+    barkAllowance : double;
+    rawDiameterX : double;
+    rawDiameterY : double;
+    totalArea : double;
+    woodArea : double;
+    fitError : double;
+    rawDiameterMin : double;
+    rawDiameterMax : double;
+    centerLineX : double;
+    centerLineY : double;
+}
+
+table LogModelT (fs_serializer) 
+{
+   logNumber: int32 ;
+   interval: double ;
+   timeScanned: int64;
+   length : double ;
+   sections : [LogSectionT];
+   rejectedSections: [LogSectionT];
+   encoderPulseInterval : double;
+   firstGoodProfile : ProfileT;
+   lastGoodProfile : ProfileT;
+   centerLineSlopeX: double;
+   centerLineSlopeY: double;
+   centerLineInterceptXZ : double;
+   centerLineInterceptYZ : double;
+   centerLineStart: Point3DT;
+   centerLineEnd: Point3DT;
+   smallEndDiameter: double;
+   smallEndDiameterX: double;
+   smallEndDiameterY: double;
+   largeEndDiameter: double;
+   largeEndDiameterX: double;
+   largeEndDiameterY: double;
+   sweep: double;
+   sweepAngleRad: double;
+   compoundSweep: double;
+   compoundSweep90: double;
+   taper: double;
+   taperX: double;
+   taperY: double;
+   volume: double;
+   barkVolume: double;
+   maxDiameter: double;
+   minDiameter: double;
+   maxDiameterZ: double;
+   minDiameterZ: double;
+   buttEndFirst: bool;
+   rawLog: RawLogT;
+
+
+}

--- a/src/JoeScan.LogScanner.Core.Tests/JoeScan.LogScanner.Core.Tests.csproj
+++ b/src/JoeScan.LogScanner.Core.Tests/JoeScan.LogScanner.Core.Tests.csproj
@@ -23,6 +23,13 @@
 
   <ItemGroup>
     <Folder Include="Models\" />
+    <Folder Include="Serialization\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="RawLog_7441.loga">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/JoeScan.LogScanner.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/JoeScan.LogScanner.Core.Tests/Serialization/SerializationTests.cs
@@ -1,0 +1,191 @@
+﻿using Autofac;
+using FlatSharp;
+using JoeScan.LogScanner.Core.Extensions;
+using JoeScan.LogScanner.Core.Geometry;
+using JoeScan.LogScanner.Core.Models;
+using JoeScan.LogScanner.Core.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace JoeScan.LogScanner.Core.Tests.Serialization;
+[TestClass]
+public class SerializationTests
+{
+    [TestMethod]
+    public void TestEllipseT()
+    {
+        var e = new Ellipse(new[] { 19.0, 17.0, 21.0, 23.0, 25.0 });
+        var sut = e.ToEllipseT();
+        Assert.AreEqual(19.0, sut.A); // A is always the larger of the two radii
+        Assert.AreEqual(17.0, sut.B);
+        Assert.AreEqual(21.0, sut.Theta);
+        Assert.AreEqual(23.0, sut.X);
+        Assert.AreEqual(25.0, sut.Y);
+        int maxBytesNeeded = EllipseT.Serializer.GetMaxSize(sut);
+        byte[] buffer = new byte[maxBytesNeeded]; 
+        int bytesWritten = EllipseT.Serializer.Write(buffer,sut);
+
+        var sut2 = EllipseT.Serializer.Parse(buffer);
+        Assert.AreEqual(sut.A, sut2.A);
+        Assert.AreEqual(sut.B, sut2.B);
+        Assert.AreEqual(sut.Theta, sut2.Theta);
+        Assert.AreEqual(sut.X, sut2.X);
+        Assert.AreEqual(sut.Y, sut2.Y);
+    }
+
+    [TestMethod]
+    public void TestProfileT()
+    {
+        var p = new Profile();
+        p.Data = new Point2D[] { new Point2D(1.0, 2.0, 3.0), new Point2D(4.0, 5.0, 6.0) };
+        p.Units = UnitSystem.Millimeters;
+        p.ScanningFlags = ScanFlags.InternalError | ScanFlags.Overrun;
+        p.LaserIndex = 1;
+        p.LaserOnTimeUs = 777;
+        p.EncoderValues = new Dictionary<uint, long>() { { 0, 2133458L } };
+        p.SequenceNumber = 1234567890;
+        p.TimeStampNs = UInt64.MaxValue;
+        p.ScanHeadId = 17;
+        p.Camera = 1;
+        p.Inputs = InputFlags.EncoderA | InputFlags.EncoderB;
+        p.BoundingBox = new Rect(1.0, 2.0, 3.0, 4.0);
+
+        var sut = p.ToProfileT();
+        Assert.AreEqual(2, sut.Data.Count);
+        Assert.AreEqual(1.0, sut.Data[0].X);
+        Assert.AreEqual(2.0, sut.Data[0].Y);
+        Assert.AreEqual(3.0, sut.Data[0].B);
+        Assert.AreEqual(4.0, sut.Data[1].X);
+        Assert.AreEqual(5.0, sut.Data[1].Y);
+        Assert.AreEqual(6.0, sut.Data[1].B);
+        Assert.AreEqual(UnitSystem.Millimeters, (UnitSystem) sut.Units);
+        Assert.AreEqual(ScanFlags.InternalError | ScanFlags.Overrun, (ScanFlags) sut.ScanningFlags);
+        Assert.AreEqual(1u, sut.LaserIndex);
+        Assert.AreEqual(777, sut.LaserOnTimeUs);
+        Assert.AreEqual(2133458L, sut.EncoderValue);
+        Assert.AreEqual(1234567890u, sut.SequenceNumber);
+        Assert.AreEqual(17u, sut.ScanHeadId);
+        Assert.AreEqual(1u, sut.Camera);
+        Assert.AreEqual(InputFlags.EncoderA | InputFlags.EncoderB, (InputFlags) sut.Inputs);
+        Assert.AreEqual(1.0, sut.BoundingBox.X);
+        Assert.AreEqual(2.0, sut.BoundingBox.Y);
+        Assert.AreEqual(3.0, sut.BoundingBox.Width);
+        Assert.AreEqual(4.0, sut.BoundingBox.Height);
+        Assert.AreEqual(UInt64.MaxValue, sut.TimeStampNs);
+
+        int maxBytesNeeded = ProfileT.Serializer.GetMaxSize(sut);
+        byte[] buffer = new byte[maxBytesNeeded];
+        int bytesWritten = ProfileT.Serializer.Write(buffer, sut);
+
+        sut = ProfileT.Serializer.Parse(buffer);
+        Assert.AreEqual(2, sut.Data.Count);
+        Assert.AreEqual(1.0, sut.Data[0].X);
+        Assert.AreEqual(2.0, sut.Data[0].Y);
+        Assert.AreEqual(3.0, sut.Data[0].B);
+        Assert.AreEqual(4.0, sut.Data[1].X);
+        Assert.AreEqual(5.0, sut.Data[1].Y);
+        Assert.AreEqual(6.0, sut.Data[1].B);
+        Assert.AreEqual(UnitSystem.Millimeters, (UnitSystem)sut.Units);
+        Assert.AreEqual(ScanFlags.InternalError | ScanFlags.Overrun, (ScanFlags)sut.ScanningFlags);
+        Assert.AreEqual(1u, sut.LaserIndex);
+        Assert.AreEqual(777, sut.LaserOnTimeUs);
+        Assert.AreEqual(2133458L, sut.EncoderValue);
+        Assert.AreEqual(1234567890u, sut.SequenceNumber);
+        Assert.AreEqual(17u, sut.ScanHeadId);
+        Assert.AreEqual(1u, sut.Camera);
+        Assert.AreEqual(InputFlags.EncoderA | InputFlags.EncoderB, (InputFlags)sut.Inputs);
+        Assert.AreEqual(1.0, sut.BoundingBox.X);
+        Assert.AreEqual(2.0, sut.BoundingBox.Y);
+        Assert.AreEqual(3.0, sut.BoundingBox.Width);
+        Assert.AreEqual(4.0, sut.BoundingBox.Height);
+        Assert.AreEqual(UInt64.MaxValue, sut.TimeStampNs);
+    }
+
+    [TestMethod]
+    public void TestRawLogT()
+    {
+        var rawLog = RawLogReaderWriter.Read("RawLog_7441.loga");
+        var sut = rawLog.ToRawLogT();
+
+        Assert.AreEqual(7441, sut.LogNumber);
+        Assert.AreEqual(rawLog.TimeScanned, DateTime.FromBinary(sut.TimeScanned));
+        Assert.AreEqual(rawLog.Id, Guid.Parse(sut.Id!));
+        Assert.AreEqual(rawLog.ProfileData.Count, sut.ProfileData!.Count);
+        
+        int maxBytesNeeded = RawLogT.Serializer.GetMaxSize(sut);
+        byte[] buffer = new byte[maxBytesNeeded];
+        int bytesWritten = RawLogT.Serializer.Write(buffer, sut);
+
+        sut = RawLogT.Serializer.Parse(buffer);
+        Assert.AreEqual(7441, sut.LogNumber);
+        Assert.AreEqual(rawLog.TimeScanned, DateTime.FromBinary(sut.TimeScanned));
+        Assert.AreEqual(rawLog.Id, Guid.Parse(sut.Id!));
+        Assert.AreEqual(rawLog.ProfileData.Count, sut.ProfileData!.Count);
+    }
+
+    [TestMethod]
+    public void TestLogModel()
+    {
+        var rawLog = RawLogReaderWriter.Read("RawLog_7441.loga");
+        var builder = new ContainerBuilder();
+        builder.RegisterModule<CoreModule>();
+        var container = builder.Build();
+
+        using var scope = container.BeginLifetimeScope();
+        var logModelBuilder = scope.Resolve<LogModelBuilder>();
+        var res = logModelBuilder.Build(rawLog);
+
+        var lm = res.LogModel;
+        var sut = lm!.ToLogModelT();
+
+        int maxBytesNeeded = LogModelT.Serializer.GetMaxSize(sut);
+        byte[] buffer = new byte[maxBytesNeeded];
+        int bytesWritten = LogModelT.Serializer.Write(buffer, sut);
+
+        sut = LogModelT.Serializer.Parse(buffer);
+        Assert.AreEqual(lm!.LogNumber, sut.LogNumber);
+        Assert.AreEqual(lm.Interval, sut.Interval);
+        Assert.AreEqual(lm.TimeScanned, DateTime.FromBinary(sut.TimeScanned));
+        Assert.AreEqual(lm.EncoderPulseInterval, sut.EncoderPulseInterval);
+        Assert.AreEqual(lm.Length, sut.Length);
+        Assert.AreEqual(lm.CenterLineSlopeX, sut.CenterLineSlopeX);
+        Assert.AreEqual(lm.CenterLineSlopeY, sut.CenterLineSlopeY);
+        Assert.AreEqual(lm.CenterLineInterceptXZ, sut.CenterLineInterceptXZ);
+        Assert.AreEqual(lm.CenterLineInterceptYZ, sut.CenterLineInterceptYZ);
+        Assert.AreEqual(lm.SmallEndDiameter, sut.SmallEndDiameter);
+        Assert.AreEqual(lm.SmallEndDiameterX, sut.SmallEndDiameterX);
+        Assert.AreEqual(lm.SmallEndDiameterY, sut.SmallEndDiameterY);
+        Assert.AreEqual(lm.LargeEndDiameter, sut.LargeEndDiameter);
+        Assert.AreEqual(lm.LargeEndDiameterX, sut.LargeEndDiameterX);
+        Assert.AreEqual(lm.LargeEndDiameterY, sut.LargeEndDiameterY);
+        Assert.AreEqual(lm.Sweep, sut.Sweep);
+        Assert.AreEqual(lm.SweepAngleRad, sut.SweepAngleRad);
+        Assert.AreEqual(lm.CompoundSweep, sut.CompoundSweep);
+        Assert.AreEqual(lm.CompoundSweep90, sut.CompoundSweep90);
+        Assert.AreEqual(lm.Taper, sut.Taper);
+        Assert.AreEqual(lm.TaperX, sut.TaperX);
+        Assert.AreEqual(lm.TaperY, sut.TaperY);
+        Assert.AreEqual(lm.Volume, sut.Volume);
+        Assert.AreEqual(lm.BarkVolume, sut.BarkVolume);
+        Assert.AreEqual(lm.MaxDiameter, sut.MaxDiameter);
+        Assert.AreEqual(lm.MaxDiameterZ, sut.MaxDiameterZ);
+        Assert.AreEqual(lm.MinDiameter, sut.MinDiameter);
+        Assert.AreEqual(lm.MinDiameterZ, sut.MinDiameterZ);
+        Assert.AreEqual(lm.ButtEndFirst, sut.ButtEndFirst);
+
+        Assert.AreEqual(lm.Sections.Count, sut.Sections!.Count);
+        Assert.AreEqual(lm.RejectedSections.Count, sut.RejectedSections!.Count);
+
+        // foreach (var tup in sut.Sections.Zip(lm.Sections, (i1, i2) => Tuple.Create(i1, i2)))
+        // {
+        //     Assert.AreEqual(tup.Item1.AcceptedPoints!.Count, tup.Item2.AcceptedPoints.Count);
+        // }
+
+    }
+}
+
+

--- a/src/JoeScan.LogScanner.Core/CoreModule.cs
+++ b/src/JoeScan.LogScanner.Core/CoreModule.cs
@@ -32,6 +32,8 @@ public class CoreModule : Module
 
 
         builder.RegisterType<DefaultConfigLocator>().As<IConfigLocator>();
+
+        builder.RegisterType<LogModelSender>().As<ILogModelSender>().SingleInstance();
        
         builder.Register(c =>
             new CoreConfig(new IniConfigSource("core.ini").Configs["Core"])).AsSelf();

--- a/src/JoeScan.LogScanner.Core/Extensions/SerializationExtensions.cs
+++ b/src/JoeScan.LogScanner.Core/Extensions/SerializationExtensions.cs
@@ -1,0 +1,178 @@
+﻿using JoeScan.LogScanner.Core.Geometry;
+using JoeScan.LogScanner.Core.Models;
+using JoeScan.LogScanner.Core.Schema;
+
+namespace JoeScan.LogScanner.Core.Extensions;
+
+public static class SerializationExtensions
+{
+    public static LogModelT ToLogModelT(this LogModel logModel)
+    {
+        var t = new LogModelT
+            {
+                LogNumber = logModel.LogNumber,
+                Interval = logModel.Interval,
+                TimeScanned = logModel.TimeScanned.ToBinary(),
+                Length = logModel.Length,
+                EncoderPulseInterval = logModel.EncoderPulseInterval,
+                FirstGoodProfile = logModel.FirstGoodProfile.ToProfileT(),
+                LastGoodProfile = logModel.LastGoodProfile.ToProfileT(),
+                CenterLineSlopeX = logModel.CenterLineSlopeX,
+                CenterLineSlopeY = logModel.CenterLineSlopeY,
+                CenterLineInterceptXZ = logModel.CenterLineInterceptXZ,
+                CenterLineInterceptYZ = logModel.CenterLineInterceptYZ,
+                CenterLineStart = logModel.CenterLineStart.ToPoint3DT(),
+                CenterLineEnd = logModel.CenterLineEnd.ToPoint3DT(),
+                SmallEndDiameter = logModel.SmallEndDiameter,
+                SmallEndDiameterX = logModel.SmallEndDiameterX,
+                SmallEndDiameterY = logModel.SmallEndDiameterY,
+                LargeEndDiameter = logModel.LargeEndDiameter,
+                LargeEndDiameterX = logModel.LargeEndDiameterX,
+                LargeEndDiameterY = logModel.LargeEndDiameterY,
+                Sweep = logModel.Sweep,
+                SweepAngleRad = logModel.SweepAngleRad,
+                CompoundSweep = logModel.CompoundSweep,
+                CompoundSweep90 = logModel.CompoundSweep90,
+                Taper = logModel.Taper,
+                TaperX = logModel.TaperX,
+                TaperY = logModel.TaperY,
+                Volume = logModel.Volume,
+                BarkVolume = logModel.BarkVolume,
+                MaxDiameter = logModel.MaxDiameter,
+                MinDiameter = logModel.MinDiameter,
+                MaxDiameterZ = logModel.MaxDiameterZ,
+                MinDiameterZ = logModel.MinDiameterZ,
+                ButtEndFirst = logModel.ButtEndFirst,
+                RawLog = logModel.RawLog.ToRawLogT(),
+                Sections = new List<LogSectionT>()
+            };
+        foreach (var section in logModel.Sections)
+        {
+            t.Sections.Add(section.ToLogSectionT());
+        }
+        t.RejectedSections = new List<LogSectionT>();
+        foreach (var section in logModel.RejectedSections)
+        {
+            t.RejectedSections.Add(section.ToLogSectionT());
+        }
+        return t;
+    }
+
+    public static LogSectionT ToLogSectionT(this LogSection logSection)
+    {
+        var s = new LogSectionT();
+        s.IsValid = logSection.IsValid;
+        s.Profiles = new List<ProfileT>();
+        foreach (var profile in logSection.Profiles)
+        {
+            s.Profiles.Add(profile.ToProfileT());
+        }
+
+        s.SectionCenter = logSection.SectionCenter;
+        s.AcceptedPoints = new List<Point2DT>();
+        foreach (var point in logSection.AcceptedPoints)
+        {
+            s.AcceptedPoints.Add(point.ToPoint2DT());
+        }
+        s.ModeledProfile = new List<Point2DT>();
+        foreach (var point in logSection.ModeledProfile)
+        {
+            s.ModeledProfile.Add(point.ToPoint2DT());
+        }
+        s.RejectedPoints = new List<Point2DT>();
+        foreach (var point in logSection.RejectedPoints)
+        {
+            s.RejectedPoints.Add(point.ToPoint2DT());
+        }
+
+        s.BoundingBox = new RectT()
+        {
+            X = logSection.BoundingBox.FilteredMinX,
+            Y = logSection.BoundingBox.FilteredMinY,
+            Width = logSection.BoundingBox.FilteredMaxX - logSection.BoundingBox.FilteredMinX,
+            Height = logSection.BoundingBox.FilteredMaxY - logSection.BoundingBox.FilteredMinY
+        };
+        s.EllipseModel = new EllipseT()
+        {
+            A = logSection.EllipseModel.A,
+            B = logSection.EllipseModel.B,
+            Theta = logSection.EllipseModel.Theta,
+            X = logSection.EllipseModel.X,
+            Y = logSection.EllipseModel.Y
+        };
+        s.BarkAllowance = logSection.BarkAllowance;
+        s.RawDiameterX = logSection.RawDiameterX;
+        s.RawDiameterY = logSection.RawDiameterY;
+        s.TotalArea = logSection.TotalArea;
+        s.WoodArea = logSection.WoodArea;
+        s.FitError = logSection.FitError;
+        s.RawDiameterMin = logSection.RawDiameterMin;
+        s.RawDiameterMax = logSection.RawDiameterMax;
+        s.CenterLineX = logSection.CenterLineX;
+        s.CenterLineY = logSection.CenterLineY;
+
+        return s;
+    }
+
+    public static RawLogT ToRawLogT(this RawLog rawLog)
+    {
+        var r = new RawLogT();
+        r.LogNumber = rawLog.LogNumber;
+        r.Id = rawLog.Id.ToString();
+        r.TimeScanned = rawLog.TimeScanned.ToBinary();
+        r.RawFileName = rawLog.ArchiveFileName;
+        r.ProfileData = new List<ProfileT>();
+        foreach (var profile in rawLog.ProfileData)
+        {
+            r.ProfileData!.Add(profile.ToProfileT());
+        }
+
+        return r;
+    }
+
+    public static ProfileT ToProfileT(this Profile p)
+    {
+        var prof = new ProfileT
+        {
+            Units = (UnitTypeT)p.Units,
+            ScanningFlags = (ScanFlagsT)p.ScanningFlags,
+            LaserIndex = p.LaserIndex,
+            LaserOnTimeUs = p.LaserOnTimeUs,
+            EncoderValue = p.EncoderValues[0],
+            SequenceNumber = p.SequenceNumber,
+            TimeStampNs = p.TimeStampNs,
+            ScanHeadId = p.ScanHeadId,
+            Camera = p.Camera,
+            Inputs = (InputFlagsT)p.Inputs,
+            BoundingBox = new RectT()
+            {
+                X = p.BoundingBox.X,
+                Y = p.BoundingBox.Y,
+                Width = p.BoundingBox.Width,
+                Height = p.BoundingBox.Height
+            },
+            Data = new List<Point2DT>()
+        };
+        foreach (var point2D in p.Data)
+        {
+            prof.Data!.Add(point2D.ToPoint2DT());
+        }
+
+        return prof;
+    }
+
+    public static Point2DT ToPoint2DT(this Point2D p)
+    {
+        return new Point2DT { X = p.X, Y = p.Y, B = p.B };
+    }
+
+    public static Point3DT ToPoint3DT(this Point3D p)
+    {
+        return new Point3DT { X = p.X, Y = p.Y, Z = p.Z, B = p.B };
+    }
+
+    public static EllipseT ToEllipseT(this Ellipse e)
+    {
+        return new EllipseT { A = e.A, B = e.B, Theta = e.Theta, X = e.X, Y = e.Y };
+    }
+}

--- a/src/JoeScan.LogScanner.Core/Extensions/SerializationExtensions.cs
+++ b/src/JoeScan.LogScanner.Core/Extensions/SerializationExtensions.cs
@@ -6,55 +6,71 @@ namespace JoeScan.LogScanner.Core.Extensions;
 
 public static class SerializationExtensions
 {
+    public static LogModelResultT ToLogModelResultT(this LogModelResult res)
+    {
+        var r = new LogModelResultT
+        {
+            LogNumber = res.LogNumber,
+            IsValid = res.IsValidModel,
+            Messages = res.Messages.ToList(),
+            RawLog = res.RawLog.ToRawLogT(),
+            LogModel = res.LogModel?.ToLogModelT()
+        };
+        return r;
+    }
+
     public static LogModelT ToLogModelT(this LogModel logModel)
     {
         var t = new LogModelT
-            {
-                LogNumber = logModel.LogNumber,
-                Interval = logModel.Interval,
-                TimeScanned = logModel.TimeScanned.ToBinary(),
-                Length = logModel.Length,
-                EncoderPulseInterval = logModel.EncoderPulseInterval,
-                FirstGoodProfile = logModel.FirstGoodProfile.ToProfileT(),
-                LastGoodProfile = logModel.LastGoodProfile.ToProfileT(),
-                CenterLineSlopeX = logModel.CenterLineSlopeX,
-                CenterLineSlopeY = logModel.CenterLineSlopeY,
-                CenterLineInterceptXZ = logModel.CenterLineInterceptXZ,
-                CenterLineInterceptYZ = logModel.CenterLineInterceptYZ,
-                CenterLineStart = logModel.CenterLineStart.ToPoint3DT(),
-                CenterLineEnd = logModel.CenterLineEnd.ToPoint3DT(),
-                SmallEndDiameter = logModel.SmallEndDiameter,
-                SmallEndDiameterX = logModel.SmallEndDiameterX,
-                SmallEndDiameterY = logModel.SmallEndDiameterY,
-                LargeEndDiameter = logModel.LargeEndDiameter,
-                LargeEndDiameterX = logModel.LargeEndDiameterX,
-                LargeEndDiameterY = logModel.LargeEndDiameterY,
-                Sweep = logModel.Sweep,
-                SweepAngleRad = logModel.SweepAngleRad,
-                CompoundSweep = logModel.CompoundSweep,
-                CompoundSweep90 = logModel.CompoundSweep90,
-                Taper = logModel.Taper,
-                TaperX = logModel.TaperX,
-                TaperY = logModel.TaperY,
-                Volume = logModel.Volume,
-                BarkVolume = logModel.BarkVolume,
-                MaxDiameter = logModel.MaxDiameter,
-                MinDiameter = logModel.MinDiameter,
-                MaxDiameterZ = logModel.MaxDiameterZ,
-                MinDiameterZ = logModel.MinDiameterZ,
-                ButtEndFirst = logModel.ButtEndFirst,
-                RawLog = logModel.RawLog.ToRawLogT(),
-                Sections = new List<LogSectionT>()
-            };
+        {
+            LogNumber = logModel.LogNumber,
+            Interval = logModel.Interval,
+            TimeScanned = logModel.TimeScanned.ToBinary(),
+            Length = logModel.Length,
+            EncoderPulseInterval = logModel.EncoderPulseInterval,
+            FirstGoodProfile = logModel.FirstGoodProfile.ToProfileT(),
+            LastGoodProfile = logModel.LastGoodProfile.ToProfileT(),
+            CenterLineSlopeX = logModel.CenterLineSlopeX,
+            CenterLineSlopeY = logModel.CenterLineSlopeY,
+            CenterLineInterceptXZ = logModel.CenterLineInterceptXZ,
+            CenterLineInterceptYZ = logModel.CenterLineInterceptYZ,
+            CenterLineStart = logModel.CenterLineStart.ToPoint3DT(),
+            CenterLineEnd = logModel.CenterLineEnd.ToPoint3DT(),
+            SmallEndDiameter = logModel.SmallEndDiameter,
+            SmallEndDiameterX = logModel.SmallEndDiameterX,
+            SmallEndDiameterY = logModel.SmallEndDiameterY,
+            LargeEndDiameter = logModel.LargeEndDiameter,
+            LargeEndDiameterX = logModel.LargeEndDiameterX,
+            LargeEndDiameterY = logModel.LargeEndDiameterY,
+            Sweep = logModel.Sweep,
+            SweepAngleRad = logModel.SweepAngleRad,
+            CompoundSweep = logModel.CompoundSweep,
+            CompoundSweep90 = logModel.CompoundSweep90,
+            Taper = logModel.Taper,
+            TaperX = logModel.TaperX,
+            TaperY = logModel.TaperY,
+            Volume = logModel.Volume,
+            BarkVolume = logModel.BarkVolume,
+            MaxDiameter = logModel.MaxDiameter,
+            MinDiameter = logModel.MinDiameter,
+            MaxDiameterZ = logModel.MaxDiameterZ,
+            MinDiameterZ = logModel.MinDiameterZ,
+            ButtEndFirst = logModel.ButtEndFirst,
+            // we don't reference the RawLog here, it is part of LogModelResultT
+            // RawLog = logModel.RawLog.ToRawLogT(), 
+            Sections = new List<LogSectionT>()
+        };
         foreach (var section in logModel.Sections)
         {
             t.Sections.Add(section.ToLogSectionT());
         }
+
         t.RejectedSections = new List<LogSectionT>();
         foreach (var section in logModel.RejectedSections)
         {
             t.RejectedSections.Add(section.ToLogSectionT());
         }
+
         return t;
     }
 
@@ -74,11 +90,13 @@ public static class SerializationExtensions
         {
             s.AcceptedPoints.Add(point.ToPoint2DT());
         }
+
         s.ModeledProfile = new List<Point2DT>();
         foreach (var point in logSection.ModeledProfile)
         {
             s.ModeledProfile.Add(point.ToPoint2DT());
         }
+
         s.RejectedPoints = new List<Point2DT>();
         foreach (var point in logSection.RejectedPoints)
         {
@@ -173,6 +191,13 @@ public static class SerializationExtensions
 
     public static EllipseT ToEllipseT(this Ellipse e)
     {
-        return new EllipseT { A = e.A, B = e.B, Theta = e.Theta, X = e.X, Y = e.Y };
+        return new EllipseT
+        {
+            A = e.A,
+            B = e.B,
+            Theta = e.Theta,
+            X = e.X,
+            Y = e.Y
+        };
     }
 }

--- a/src/JoeScan.LogScanner.Core/Interfaces/ILogModelSender.cs
+++ b/src/JoeScan.LogScanner.Core/Interfaces/ILogModelSender.cs
@@ -1,0 +1,8 @@
+﻿using JoeScan.LogScanner.Core.Models;
+
+namespace JoeScan.LogScanner.Core.Interfaces;
+
+public interface ILogModelSender
+{
+    Task SendAsync(LogModelResult result, CancellationToken cancellationToken = default);
+}

--- a/src/JoeScan.LogScanner.Core/Interfaces/ILogModelSender.cs
+++ b/src/JoeScan.LogScanner.Core/Interfaces/ILogModelSender.cs
@@ -5,4 +5,6 @@ namespace JoeScan.LogScanner.Core.Interfaces;
 public interface ILogModelSender
 {
     Task SendAsync(LogModelResult result, CancellationToken cancellationToken = default);
+    void Start();
+    void Stop();
 }

--- a/src/JoeScan.LogScanner.Core/JoeScan.LogScanner.Core.csproj
+++ b/src/JoeScan.LogScanner.Core/JoeScan.LogScanner.Core.csproj
@@ -35,6 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\JoeScan.LogScanner.Core.Schema\JoeScan.LogScanner.Core.Schema.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="core.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/JoeScan.LogScanner.Core/Models/LogModelSender.cs
+++ b/src/JoeScan.LogScanner.Core/Models/LogModelSender.cs
@@ -1,0 +1,12 @@
+﻿using JoeScan.LogScanner.Core.Interfaces;
+
+namespace JoeScan.LogScanner.Core.Models;
+
+public class LogModelSender : ILogModelSender
+{
+    public Task SendAsync(LogModelResult result, CancellationToken cancellationToken = default)
+    {
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/JoeScan.LogScanner.Core/Models/LogModelSender.cs
+++ b/src/JoeScan.LogScanner.Core/Models/LogModelSender.cs
@@ -1,12 +1,161 @@
-﻿using JoeScan.LogScanner.Core.Interfaces;
+﻿using FlatSharp;
+using JoeScan.LogScanner.Core.Extensions;
+using JoeScan.LogScanner.Core.Interfaces;
+using JoeScan.LogScanner.Core.Schema;
+using MathNet.Numerics.Statistics;
+using Microsoft.Identity.Client;
+using NLog;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using Logger = NLog.Logger;
+
 
 namespace JoeScan.LogScanner.Core.Models;
 
-public class LogModelSender : ILogModelSender
+public class LogModelSender : ILogModelSender, IDisposable
 {
-    public Task SendAsync(LogModelResult result, CancellationToken cancellationToken = default)
+    private ILogger logger;
+    private const int ModelSenderPort = 10020;
+    private TcpListener? server;
+    private CancellationTokenSource? cancellationTokenSource;
+    private Thread? listenerThread;
+    private readonly List<LogModelResultTSenderClient> clients = new();
+
+    public LogModelSender(ILogger logger)
     {
-        
-        return Task.CompletedTask;
+        this.logger = logger;
+        this.logger.Debug("Created LogModelSender");
+    }
+
+    public void Start()
+    {
+        logger.Debug("Starting LogModelSender");
+        if (cancellationTokenSource == null)
+        {
+            cancellationTokenSource = new CancellationTokenSource();
+            listenerThread = new Thread(() => StartListener(cancellationTokenSource.Token));
+            listenerThread.Start();
+        }
+        else
+        {
+            logger.Debug("LogModelSender already started");
+        }
+    }
+
+    public void Stop()
+    {
+        logger.Debug("Stopping LogModelSender");
+        if (cancellationTokenSource != null)
+        {
+            cancellationTokenSource.Cancel();
+            listenerThread!.Join();
+            cancellationTokenSource.Dispose();
+            cancellationTokenSource = null;
+            logger.Debug("LogModelSender stopped");
+        }
+        else
+        {
+            logger.Debug("LogModelSender already stopped");
+        }
+    }
+
+    private async void StartListener(object token)
+    {
+        var cancellationToken = (CancellationToken)token;
+        server = new TcpListener(IPAddress.Any, ModelSenderPort);
+        server.Start();
+        logger.Debug($"LogModelSender listening on port {ModelSenderPort} for clients.");
+
+        try
+        {
+            while (true)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    logger.Debug("LogModelSender cancellation requested");
+                    break;
+                }
+
+                logger.Debug("Waiting for a connection...");
+                var client = await server!.AcceptTcpClientAsync(cancellationToken);
+
+                logger.Debug("Connected!");
+                var t = new LogModelResultTSenderClient(client, $"Client #{clients.Count + 1}");
+                clients.Add(t);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // nothing
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Error in LogModelSender");
+        }
+        finally
+        {
+            foreach (var client in clients)
+            {
+                client.Dispose();
+            }
+        }
+
+        logger.Debug("LogModelSender listener thread exiting");
+    }
+    #region ILogModelSender Implementation
+
+    public async Task SendAsync(LogModelResult result, CancellationToken cancellationToken = default)
+    {
+        if (clients.Count == 0)
+        {
+            logger.Debug("No clients connected, not sending");
+            return;
+        }
+        var logModelResultT = result.ToLogModelResultT();
+        int maxBytesNeeded = LogModelResultT.Serializer.GetMaxSize(logModelResultT);
+        byte[] buffer = new byte[maxBytesNeeded];
+        int bytesWritten = LogModelResultT.Serializer.Write(buffer, logModelResultT);
+        // TODO: use Task.WaitAll() to send to all clients in parallel
+        foreach (var logModelResultTSenderClient in clients)
+        {
+            await logModelResultTSenderClient.Send(buffer,bytesWritten);
+        }
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        Stop();
+    }
+}
+
+internal class LogModelResultTSenderClient : IDisposable
+{
+    private string Name { get; }
+    private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+    private readonly TcpClient client;
+    private readonly NetworkStream stream;
+
+    public LogModelResultTSenderClient(TcpClient client, string name)
+    {
+        Name = name;
+        this.client = client;
+        logger.Debug($"Created LogModelResultTSenderClient {Name}");
+        stream = client.GetStream();
+    }
+    
+    public void Dispose()
+    {
+        stream.Close();
+        client.Close();
+    }
+
+    public async Task Send(byte[] data, int length)
+    { 
+        logger.Trace($"Sending {length} bytes to client.");
+        await stream.WriteAsync(BitConverter.GetBytes(length), 0, sizeof(int));
+        await stream.WriteAsync(data, 0, length);
     }
 }

--- a/src/JoeScan.LogScanner.Core/Models/Profile.cs
+++ b/src/JoeScan.LogScanner.Core/Models/Profile.cs
@@ -69,7 +69,7 @@ public class Profile : ICloneable
     /// </summary>
     public InputFlags Inputs { get; set; }
 
-    internal Rect BoundingBox { get; set; } = Rect.Empty;
+    public Rect BoundingBox { get; set; } = Rect.Empty;
 
     // TODO: add container to hold filtered data instead of throwing it away
 

--- a/src/JoeScan.LogScanner.sln
+++ b/src/JoeScan.LogScanner.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogScanner.Mebor", "..\..\L
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JoeScan.LogScanner.SyntheticDataAdapter", "adapters\JoeScan.LogScanner.SyntheticDataAdapter\JoeScan.LogScanner.SyntheticDataAdapter.csproj", "{8B4B577A-98A5-4EF6-A850-82E53F3313EB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JoeScan.LogScanner.Core.Schema", "JoeScan.LogScanner.Core.Schema\JoeScan.LogScanner.Core.Schema.csproj", "{31B1A00B-2824-451B-BC9E-0B789CFC0CA6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,10 @@ Global
 		{8B4B577A-98A5-4EF6-A850-82E53F3313EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B4B577A-98A5-4EF6-A850-82E53F3313EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B4B577A-98A5-4EF6-A850-82E53F3313EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31B1A00B-2824-451B-BC9E-0B789CFC0CA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31B1A00B-2824-451B-BC9E-0B789CFC0CA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31B1A00B-2824-451B-BC9E-0B789CFC0CA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31B1A00B-2824-451B-BC9E-0B789CFC0CA6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "7.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
this is a first implementation of LogModelSender. The LogScannerEngine creates a LogModelSender automatically, acting as a server. Clients can connect on port 10020, and read the serialized data for a complete LogModelResultT. 
Any plugins are no longer called.
To use the data: the serialization is done via Flatbuffers and implemented in a library, JoeScan.LogScanner.Core.Schema
You must include this library as a reference. 
When reading the serialized data, the first for bytes (int32) contain the length that follows. 
Once you have the full buffer, you can very easily just call 
LogModelResultT.Serializer.Parse(buffer) and it will give you a fully populated LogModelResultT (which is defined in the Schema). See the unit tests in Core.Tests for usage. The classes are auto-generated from the flatbuffer schema file (fbs) as part of building LogScanner.Core.Schema. 
I deliberately did not use the types in Core (LogModel, RawLog etc.) and instead created serializable proxy classes, but for all intents and purposes they are the same and hold the same data. This way, your client application does not need to link against core. 

